### PR TITLE
Update Health-Connect site copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 		<title>evermed(research)</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="description" content="Health-Connect turns connected clinical data into workflow intelligence for quality, compliance, documentation, and provider operations, with the evrConnect iOS companion app." />
+		<meta name="description" content="Health-Connect turns connected clinical data into workflow intelligence for data quality, PIQI scorecards, compliance, documentation, claims follow-up, and provider operations, with the evrConnect iOS companion app." />
 		<!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
@@ -805,8 +805,8 @@
 					<div class="hero-copy">
 						<span class="eyebrow">Healthcare workflow intelligence</span>
 						<h1>Turn connected clinical data into operational action.</h1>
-						<p class="lede">Health-Connect is an intelligence layer for quality programs, compliance readiness, documentation-sensitive workflows, and provider-facing decision support. It helps teams move from normalized data to prioritized action.</p>
-						<p class="support">Built for providers, health systems, and interoperability partners that need actionable outputs inside existing environments. evrConnect extends targeted mobile assessment workflows as the companion iOS app.</p>
+						<p class="lede">Health-Connect is an intelligence layer for data quality, PIQI scorecards, quality programs, compliance readiness, documentation-sensitive workflows, revenue-cycle follow-up, and provider-facing decision support. It helps teams move from normalized data to prioritized action.</p>
+						<p class="support">Built for providers, health systems, and interoperability partners that need actionable outputs inside existing environments, including Kahn-scored HL7 ingest quality, PIQI normalization lift, and an AI Claims Agent for low-dollar payer follow-up. evrConnect extends targeted mobile assessment workflows as the companion iOS app.</p>
 
 						<div class="cta-row">
 							<a href="#health-connect-inquiry" class="cta-link primary">
@@ -821,8 +821,8 @@
 
 						<div class="stat-row">
 							<div class="stat-chip">
-								<strong>22 AI agents</strong>
-								<span>Focused across documentation, quality, compliance, and provider-facing workflow support.</span>
+								<strong>AI + DQ work lanes</strong>
+								<span>Focused across data quality, documentation, quality, compliance, claims follow-up, and provider-facing workflow support.</span>
 							</div>
 							<div class="stat-chip">
 								<strong>92 quality measures</strong>
@@ -843,8 +843,9 @@
 						<p class="card-kicker">What it delivers</p>
 						<h2>Operational intelligence teams can use without adopting a brand-new workflow layer.</h2>
 						<ul class="hero-list">
+							<li><i class="fa-solid fa-check"></i><span>PIQI scorecards, Kahn-dimension ingest quality, and normalization lift tracking across connected feeds.</span></li>
 							<li><i class="fa-solid fa-check"></i><span>Gap identification, prioritization, and measure tracking across major quality and reporting workflows.</span></li>
-							<li><i class="fa-solid fa-check"></i><span>Documentation, revenue integrity, and compliance-ready review support for specialized operational teams.</span></li>
+							<li><i class="fa-solid fa-check"></i><span>Documentation, revenue integrity, payer follow-up, and compliance-ready review support for specialized operational teams.</span></li>
 							<li><i class="fa-solid fa-check"></i><span>Transportable, standards-based outputs that can fit into existing portals, dashboards, and connected systems.</span></li>
 						</ul>
 						<div class="signal-panel">
@@ -866,6 +867,18 @@
 				</div>
 
 				<div class="spotlight-grid">
+					<article class="spotlight-card">
+						<h3>PIQI and Kahn data quality</h3>
+						<p>Review HL7 ingest quality across conformance, completeness, plausibility, timeliness, and uniqueness, then map those Kahn dimensions into PIQI accuracy, conformity, and availability scorecards.</p>
+					</article>
+					<article class="spotlight-card">
+						<h3>Normalization lift and quarantine review</h3>
+						<p>Show raw-vs-normalized PIQI lift, facility scorecards, and quarantine-not-reject queues where clinical SMEs can release, discard, or map local-code issues.</p>
+					</article>
+					<article class="spotlight-card">
+						<h3>Claims Agent work queue</h3>
+						<p>Import or enter low-dollar payer claims, enqueue selected batches, monitor call runs, and preserve transcripts, outcomes, retries, and needs-human escalations for billing team review.</p>
+					</article>
 					<article class="spotlight-card">
 						<h3>DRG and documentation review</h3>
 						<p>See documentation-sensitive review surface as an actionable alert, with workflow guardrails that prevent duplicate single-patient work from spawning when a case is already in progress.</p>
@@ -898,6 +911,21 @@
 
 				<div class="feature-grid">
 					<article class="feature-card">
+						<i class="fa-solid fa-chart-line"></i>
+						<h3>PIQI data-quality scorecards</h3>
+						<p>Score patient information quality by use case, facility, and dimension, with drill-down into quarantine-eligible records.</p>
+					</article>
+					<article class="feature-card">
+						<i class="fa-solid fa-code-branch"></i>
+						<h3>Kahn framework ingest scoring</h3>
+						<p>Track HL7 feed quality across conformance, completeness, plausibility, timeliness, and uniqueness before data reaches downstream workflows.</p>
+					</article>
+					<article class="feature-card">
+						<i class="fa-solid fa-phone-volume"></i>
+						<h3>Claims follow-up automation</h3>
+						<p>Queue low-dollar claims for AI voice follow-up, keep operators in control of the fleet, and route ambiguous outcomes to a human worklist.</p>
+					</article>
+					<article class="feature-card">
 						<i class="fa-solid fa-heart-pulse"></i>
 						<h3>Quality intelligence</h3>
 						<p>Identify and prioritize actionable gaps across major quality and reporting workflows.</p>
@@ -920,6 +948,14 @@
 				</div>
 
 				<div class="spotlight-grid">
+					<article class="spotlight-card">
+						<h3>Data quality and integration teams</h3>
+						<p>Give interface teams feed-level quality windows, per-patient rollups, normalization dry-runs, and SME review queues for local-code and quarantine work.</p>
+					</article>
+					<article class="spotlight-card">
+						<h3>Revenue cycle operations</h3>
+						<p>Give billing teams a controlled claims-agent queue for small-balance payer follow-up, with run history and structured outcomes instead of manual one-off phone work.</p>
+					</article>
 					<article class="spotlight-card">
 						<h3>Care coordination teams</h3>
 						<p>Give care coordinators and care managers prioritized worklists instead of forcing chart-by-chart review after the report is already generated.</p>
@@ -957,8 +993,24 @@
 							</div>
 							<span class="product-chip">Patent pending</span>
 						</div>
-						<p>Workflow intelligence platform for quality programs, documentation-sensitive review, compliance readiness, and standards-based clinical insight delivery, with evrConnect as its companion iOS experience.</p>
+						<p>Workflow intelligence platform for data quality, PIQI scorecards, quality programs, documentation-sensitive review, claims follow-up, compliance readiness, and standards-based clinical insight delivery, with evrConnect as its companion iOS experience.</p>
 						<a href="#health-connect-inquiry" class="card-link">Start a provider conversation</a>
+					</article>
+
+					<article class="product-card">
+						<div class="product-head">
+							<h3>PIQI Data Quality</h3>
+							<span class="product-chip">Health-Connect module</span>
+						</div>
+						<p>Patient Information Quality Improvement scorecards for HEDIS/quality submission readiness and USCDI/TEFCA exchange, backed by shared SAM checks and Kahn-to-PIQI ingest rollups.</p>
+					</article>
+
+					<article class="product-card">
+						<div class="product-head">
+							<h3>Claims Agent</h3>
+							<span class="product-chip">Health-Connect module</span>
+						</div>
+						<p>AI voice workflow for low-dollar payer claims, with Rails-based claim intake, batch enqueueing, fleet pause/resume controls, call run history, structured outcomes, and a needs-human review queue.</p>
 					</article>
 
 					<article class="product-card">
@@ -1002,7 +1054,7 @@
 					<article class="service-card">
 						<i class="fa-solid fa-robot"></i>
 						<h3>Custom AI agent builds</h3>
-						<p>Domain-tuned systems for clinical, operational, and workflow-specific use cases.</p>
+						<p>Domain-tuned systems for clinical, revenue-cycle, operational, and workflow-specific use cases.</p>
 						<ul class="service-list">
 							<li>RAG and knowledge grounding on internal data</li>
 							<li>Web, EMR, and API delivery patterns</li>
@@ -1022,9 +1074,10 @@
 					<article class="service-card">
 						<i class="fa-solid fa-notes-medical"></i>
 						<h3>Healthcare interoperability</h3>
-						<p>Practical interface work for clinical systems, data normalization, and PHI-aware architecture.</p>
+						<p>Practical interface work for clinical systems, data-quality scoring, normalization, and PHI-aware architecture.</p>
 						<ul class="service-list">
 							<li>FHIR, HL7v2, CCD, and CCDA integration</li>
+							<li>PIQI, Kahn-dimension scoring, and normalization review lanes</li>
 							<li>Analytics and LLM-ready data pipelines</li>
 							<li>HIPAA-conscious systems design</li>
 						</ul>
@@ -1038,7 +1091,7 @@
 				<div class="section-header">
 					<span class="eyebrow">Contact</span>
 					<h2>Request the Health-Connect workflow walkthrough.</h2>
-					<p>Use the short form below to route the conversation around DRG review, quality triage, accreditation readiness, program visibility, or interoperability fit. The page stays static for now, so submissions open a structured email draft with your details prefilled.</p>
+					<p>Use the short form below to route the conversation around data quality, PIQI scorecards, claims follow-up, DRG review, quality triage, accreditation readiness, program visibility, or interoperability fit. The page stays static for now, so submissions open a structured email draft with your details prefilled.</p>
 				</div>
 
 				<div class="contact-grid">
@@ -1046,7 +1099,7 @@
 						<i class="fa-solid fa-clipboard-list"></i>
 						<h3>Tell us what you want to see</h3>
 						<p>Share a few details so the first conversation can focus on the right workflow, target users, and deployment context instead of starting from scratch.</p>
-						<p class="form-helper">Using athenahealth in your practice or provider group? Ask for the SMART on FHIR walkthrough and we will route the conversation accordingly.</p>
+						<p class="form-helper">Working on data-quality lift, small-balance payer claims, or athenahealth connectivity? Ask for the PIQI, Claims Agent, or SMART on FHIR walkthrough and we will route the conversation accordingly.</p>
 						<form class="contact-form" id="hc-form">
 							<input type="hidden" name="source" value="evermedresearch.org/health-connect" />
 							<div class="form-grid">
@@ -1070,6 +1123,8 @@
 									<label for="hc-interest">Primary interest</label>
 									<select id="hc-interest" name="interest" required>
 										<option value="">Select one</option>
+										<option value="PIQI data quality and normalization lift">PIQI data quality and normalization lift</option>
+										<option value="Claims Agent and revenue-cycle follow-up">Claims Agent and revenue-cycle follow-up</option>
 										<option value="DRG and documentation review">DRG and documentation review</option>
 										<option value="Quality triage and reporting workflows">Quality triage and reporting workflows</option>
 										<option value="Accreditation and compliance readiness">Accreditation and compliance readiness</option>
@@ -1096,8 +1151,8 @@
 					<article class="contact-card">
 						<i class="fa-solid fa-hospital-user"></i>
 						<h3>Direct provider conversation</h3>
-						<p>Use this path if you already know the walkthrough should focus on quality workflows, compliance readiness, or documentation-sensitive review.</p>
-						<a href="mailto:evermed@evermedresearch.org?subject=Health-Connect%20Business%20Inquiry&body=Hi%2C%0A%0AI%27m%20interested%20in%20learning%20more%20about%20Health-Connect%20for%20our%20organization.%0A%0AOrganization%3A%20%0ARole%3A%20%0AUse%20case%3A%20%0A%0AThank%20you!" class="contact-line">
+						<p>Use this path if you already know the walkthrough should focus on data quality, claims follow-up, quality workflows, compliance readiness, or documentation-sensitive review.</p>
+						<a href="mailto:evermed@evermedresearch.org?subject=Health-Connect%20Business%20Inquiry&body=Hi%2C%0A%0AI%27m%20interested%20in%20learning%20more%20about%20Health-Connect%20for%20our%20organization.%0A%0AOrganization%3A%20%0ARole%3A%20%0AUse%20case%3A%20%0APIQI%20or%20data-quality%20interest%3A%20%0AClaims%20Agent%20interest%3A%20%0A%0AThank%20you!" class="contact-line">
 							<i class="fa-solid fa-envelope"></i>
 							evermed@evermedresearch.org
 						</a>


### PR DESCRIPTION
## Summary

Updates the evermedresearch.org Health-Connect landing page copy to cover recent product work:

- Adds PIQI data-quality scorecards, Kahn framework ingest scoring, normalization lift, and quarantine-not-reject review language.
- Adds the Claims Agent revenue-cycle follow-up lane across hero, demo, platform, product, service, and contact copy.
- Updates the contact form interest options and mailto body so PIQI/data-quality and Claims Agent requests route clearly.

## Validation

- Reviewed Health-Connect source docs and UI code for PIQI, Kahn mapping, normalization review, executive rollups, and Claims Agent behavior.
- Ran a CRLF-aware trailing whitespace check for `index.html`.
- Confirmed the diff is scoped to `index.html` only.

Note: in-app browser automation could not refresh the local `file://` page because the browser security policy blocks file URL navigation.